### PR TITLE
Move crate to crate::json

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,10 +2,10 @@ use std::ptr;
 use std::io::Write;
 use std::io;
 
-use crate::JsonValue;
-use crate::number::Number;
-use crate::object::Object;
-use crate::util::print_dec;
+use crate::json::JsonValue;
+use crate::json::number::Number;
+use crate::json::object::Object;
+use crate::json::util::print_dec;
 
 const QU: u8 = b'"';
 const BS: u8 = b'\\';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ pub mod iterators {
 pub use Error as JsonError;
 
 #[deprecated(since="0.9.0", note="use `json::Result` instead")]
-pub use crate::Result as JsonResult;
+pub use crate::json::Result as JsonResult;
 
 pub use parser::parse;
 
@@ -278,7 +278,7 @@ pub fn stringify_pretty<T>(root: T, spaces: u16) -> String where T: Into<JsonVal
 /// ```
 #[macro_export]
 macro_rules! array {
-    [] => ($crate::JsonValue::new_array());
+    [] => ($crate::json::JsonValue::new_array());
 
     // Handles for token tree items
     [@ITEM($( $i:expr, )*) $item:tt, $( $cont:tt )+] => {
@@ -317,7 +317,7 @@ macro_rules! array {
             array.push($i.into());
         )*
 
-        $crate::JsonValue::Array(array)
+        $crate::json::JsonValue::Array(array)
     });
 
     // Entry point to the macro
@@ -330,7 +330,7 @@ macro_rules! array {
 /// Helper crate for converting types into `JsonValue`. It's used
 /// internally by the `object!` and `array!` macros.
 macro_rules! value {
-    ( null ) => { $crate::Null };
+    ( null ) => { $crate::json::Null };
     ( [$( $token:tt )*] ) => {
         // 10
         $crate::array![ $( $token )* ]
@@ -360,7 +360,7 @@ macro_rules! value {
 #[macro_export]
 macro_rules! object {
     // Empty object.
-    {} => ($crate::JsonValue::new_object());
+    {} => ($crate::json::JsonValue::new_object());
 
     // Handles for different types of keys
     (@ENTRY($( $k:expr => $v:expr, )*) $key:ident: $( $cont:tt )*) => {
@@ -405,13 +405,13 @@ macro_rules! object {
     // Construct the actual object
     (@END $( $k:expr => $v:expr, )*) => ({
         let size = 0 $( + {let _ = &$k; 1} )*;
-        let mut object = $crate::object::Object::with_capacity(size);
+        let mut object = $crate::json::object::Object::with_capacity(size);
 
         $(
             object.insert($k, $v.into());
         )*
 
-        $crate::JsonValue::Object(object)
+        $crate::json::JsonValue::Object(object)
     });
 
     // Entry point to the macro

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,8 +1,8 @@
 use std::{ ops, fmt, f32, f64 };
 use std::convert::{TryFrom, Infallible};
 use std::num::{FpCategory, TryFromIntError};
-use crate::util::grisu2;
-use crate::util::print_dec;
+use crate::json::util::grisu2;
+use crate::json::util::print_dec;
 
 /// NaN value represented in `Number` type. NaN is equal to itself.
 pub const NAN: Number = Number {

--- a/src/object.rs
+++ b/src/object.rs
@@ -2,8 +2,8 @@ use std::{ ptr, mem, str, slice, vec, fmt };
 use std::ops::{ Index, IndexMut, Deref };
 use std::iter::FromIterator;
 
-use crate::codegen::{ DumpGenerator, Generator, PrettyGenerator };
-use crate::value::JsonValue;
+use crate::json::codegen::{ DumpGenerator, Generator, PrettyGenerator };
+use crate::json::value::JsonValue;
 
 const KEY_BUF_LEN: usize = 32;
 static NULL: JsonValue = JsonValue::Null;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,9 +20,9 @@
 use std::{str, slice};
 use std::char::decode_utf16;
 use std::convert::TryFrom;
-use crate::object::Object;
-use crate::number::Number;
-use crate::{JsonValue, Error, Result};
+use crate::json::object::Object;
+use crate::json::number::Number;
+use crate::json::{JsonValue, Error, Result};
 
 // This is not actual max precision, but a threshold at which number parsing
 // kicks into checked math.
@@ -766,11 +766,11 @@ pub fn parse(source: &str) -> Result<JsonValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stringify;
-    use crate::JsonValue;
+    use crate::json::stringify;
+    use crate::json::JsonValue;
 
-    use crate::object;
-    use crate::array;
+    use crate::json::object;
+    use crate::json::array;
 
     use std::fs::File;
     use std::io::prelude::*;

--- a/src/util/grisu2.rs
+++ b/src/util/grisu2.rs
@@ -15,7 +15,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::util::diyfp::{ self, DiyFp };
+use crate::json::util::diyfp::{ self, DiyFp };
 
 #[inline]
 unsafe fn grisu_round(buffer: &mut u64, delta: u64, mut rest: u64, ten_kappa: u64, wp_w: u64) {

--- a/src/value/implements.rs
+++ b/src/value/implements.rs
@@ -3,10 +3,10 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use crate::short::{self, Short};
-use crate::number::Number;
-use crate::object::Object;
-use crate::value::JsonValue;
+use crate::json::short::{self, Short};
+use crate::json::number::Number;
+use crate::json::object::Object;
+use crate::json::value::JsonValue;
 
 macro_rules! implement_eq {
     ($to:ident, $from:ty) => {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -3,12 +3,12 @@ use std::convert::TryInto;
 use std::{fmt, mem, usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32};
 use std::io::{self, Write};
 
-use crate::{Result, Error};
-use crate::short::Short;
-use crate::number::Number;
-use crate::object::Object;
-use crate::iterators::{ Members, MembersMut, Entries, EntriesMut };
-use crate::codegen::{ Generator, PrettyGenerator, DumpGenerator, WriterGenerator, PrettyWriterGenerator };
+use crate::json::{Result, Error};
+use crate::json::short::Short;
+use crate::json::number::Number;
+use crate::json::object::Object;
+use crate::json::iterators::{ Members, MembersMut, Entries, EntriesMut };
+use crate::json::codegen::{ Generator, PrettyGenerator, DumpGenerator, WriterGenerator, PrettyWriterGenerator };
 
 mod implements;
 


### PR DESCRIPTION
Enable the crate to be vendored in another crate at `crate::json`.

This is mostly a search-and-replace of `crate` → `crate::json`.